### PR TITLE
Update dates for 2025

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -8,7 +8,7 @@
 # Site settings
 title: "Team 3128: Aluminium Narwhals"
 email: info@team3128.org
-description: "Copyright © 2015-2024 Team 3128: Aluminum Narwhals"
+description: "Copyright © 2015-2025 Team 3128: Aluminum Narwhals"
 baseurl: ""
 url: "https://team3128.org"
 github_username: Team3128

--- a/_data/resources.yml
+++ b/_data/resources.yml
@@ -21,35 +21,17 @@
 #   link: https://docs.google.com/presentation/d/1Bfxi1IMxTQ-Oio1klFpzVsyv8czBfIgeRORGaaUGJ0c/edit#slide=
 #   description: The link to the Parent Information Night Presentation
 
-#- name: 2023-2024 Handbook
-#  category: info
-#  type: link
-#  link: https://docs.google.com/document/d/1IsABwOmq6wGPpTip8KwKWtAobRK0flMNmsGCDEmx5CA/edit?usp=sharing
-#  description: The link to the 2023-2024 Team 3128 handbook.
+- name: 2025 Championship Information Presentation
+  category: info
+  type: link
+  link: https://docs.google.com/presentation/d/1g6YQxhOf4CG8rJjLlWqNaDZNNQa--QEpnvy5YWcq76o/edit?usp=sharing
+  description: The link to the 2025 Houston World Championship Info Presentation
 
-# - name: 2024 FIRST Championship Info Presentation
-#   category: info
-#   type: link
-#   link: https://docs.google.com/presentation/d/1VAVcokKsHEMdnalrSJyZhpVxCbA5Tyf-cZAf0NrrtQA/edit?usp=sharing
-#   description: The link to the 2024 FIRST Houston Championship Information slides presentation given on March 20th
-
-# - name: 2024 FIRST Championship Commitment Form
-#   category: info
-#   type: link
-#   link: https://drive.google.com/file/d/187s5r_19JsMcz1PthHYsRKZ6LfpXAiQE/view?usp=drivesdk
-#   description: The link to the 2024 FIRST Houston Championship Travel Commitment form
-
-# - name: 2024 AVR Travel Commitment Form
-#   category: info
-#   type: link
-#   link: https://docs.google.com/document/d/1yk3s-1DTix-0rC517kuYz8couIH-kzWcVWDVVFnROyo/edit?usp=sharing
-#   description: The link to the 2024 Arizona Valley Regional Travel Commitment form
-
-# - name: 2024 AVR Parent Info Presentation
-#   category: info
-#   type: link
-#   link: https://docs.google.com/presentation/d/19_ZEXJorcvTGQqbnaBaFGCj0bbzD0xnm8ZZcYNZO-KA/edit?usp=sharing
-#   description: The link to the 2024 Arizona Valley Regional Parent Info slide deck
+- name: 2025 Championship Commitment Form
+  category: info
+  type: link
+  link: https://drive.google.com/file/d/187s5r_19JsMcz1PthHYsRKZ6LfpXAiQE/view?usp=sharing
+  description: The link to the commitment form for the 2025 Houston World Championship
   
 - name: 2024-2025 Handbook
   category: info

--- a/about/robots.html
+++ b/about/robots.html
@@ -29,7 +29,7 @@ permalink: /about/robots/
 
           </h3>
 
-        <a target="_blank" rel="noopener noreferrer" href="{% if robot.year == 2024 %} http://www.firstinspires.org/resource-library/frc/competition-manual-qa-system {% else %} http://www.firstinspires.org/resource-library/frc/archived-game-documentation {% endif %}"><h4>{{ robot.year }} - {{ robot.game }}</h4></a>
+        <a target="_blank" rel="noopener noreferrer" href="{% if robot.year == 2025 %} http://www.firstinspires.org/resource-library/frc/competition-manual-qa-system {% else %} http://www.firstinspires.org/resource-library/frc/archived-game-documentation {% endif %}"><h4>{{ robot.year }} - {{ robot.game }}</h4></a>
         {% if robot.stats == true %}
           <b>Dimensions: </b>{{ robot.dimensions }}
           <br>

--- a/members/faq.md
+++ b/members/faq.md
@@ -73,12 +73,12 @@ Through the locked gate, the first left is The Nest.  If you continue walking an
 
 Pretty much. You are required to attend at least 75% of all meetings each month. 
 Ask your Department Coordinator for more specific information regarding your department's meetings.  
-Please see our [2023-2024 Team Handbook](https://docs.google.com/document/d/1IsABwOmq6wGPpTip8KwKWtAobRK0flMNmsGCDEmx5CA/edit?usp=sharing) for more information.
+Please see our [Team Handbook](https://docs.google.com/document/d/1IsABwOmq6wGPpTip8KwKWtAobRK0flMNmsGCDEmx5CA/edit?usp=sharing) for more information.
 
 
 ## **Is it mandatory that I stay for the entire meeting?**
 
-You are expected to stay for the entire meeting. If you need to leave early, then be sure to contact your department coordinator ahead of time.  Please see our [2023-2024 Team Handbook](https://docs.google.com/document/d/1IsABwOmq6wGPpTip8KwKWtAobRK0flMNmsGCDEmx5CA/edit?usp=sharing) for more information.
+You are expected to stay for the entire meeting. If you need to leave early, then be sure to contact your department coordinator ahead of time.  Please see our [Team Handbook](https://docs.google.com/document/d/1IsABwOmq6wGPpTip8KwKWtAobRK0flMNmsGCDEmx5CA/edit?usp=sharing) for more information.
 
 ## **I have a fall sport. Can I be involved?**
 
@@ -86,7 +86,7 @@ If you can manage the time commitment of the Robotics Team and a Sport - yes.
 
 If a student is a multi-sport athlete, we have found that students are spread too thin to meaningfully participate in Robotics.  
 
-Please see our [2023-2024 Team Handbook](https://docs.google.com/document/d/1IsABwOmq6wGPpTip8KwKWtAobRK0flMNmsGCDEmx5CA/edit?usp=sharing) for more information.
+Please see our [Team Handbook](https://docs.google.com/document/d/1IsABwOmq6wGPpTip8KwKWtAobRK0flMNmsGCDEmx5CA/edit?usp=sharing) for more information.
 
 
 ## **Who goes to your competitions? What are competition positions? Who are they open to?**

--- a/members/leadership.md
+++ b/members/leadership.md
@@ -14,4 +14,4 @@ Our two Co-Presidents are elected in May by a team vote by all active Juniors, S
 
 ### Appointed Positions
 
-Our Leadership Team, Coaches and Mentors create appointed positions when needed. Appointed officers are in charge of specific parts of the team that leadership has deemed necessary. These positions are created to fit the various needs of the team, and are subject to change over time. For the 2023-2024 season, each of our departments will have a Departmet Coordinator and multiple Project Leads. [Learn more about our departments](/about/departments/).
+Our Leadership Team, Coaches and Mentors create appointed positions when needed. Appointed officers are in charge of specific parts of the team that leadership has deemed necessary. These positions are created to fit the various needs of the team, and are subject to change over time. For the 2024-2025 season, each of our departments will have a Department Coordinator and multiple Project Leads. [Learn more about our departments](/about/departments/).

--- a/members/safety.md
+++ b/members/safety.md
@@ -13,7 +13,7 @@ We work with a lot of cool tools and hardware on our team, and while these enabl
 Note that these steps do not allow you to start using power tools, but these are **required** for entry and use of the workshop. 
 <!--Returning members must complete training **by September 7th, 2020** and new members must complete training **by October 9th, 2020**.
 -->
-1. Review the [FIRST 2024 Safety Manual](https://www.firstinspires.org/sites/default/files/uploads/resource_library/frc/team-resources/safety/ftc-frc-safety-manual.pdf).
+1. Review the [FIRST 2024-25 Safety Manual](https://www.firstinspires.org/sites/default/files/uploads/resource_library/frc/team-resources/safety/ftc-frc-safety-manual.pdf).
 2. Review the [Team 3128 Workshop Safety Rules](https://docs.google.com/document/d/1nYqvwFn5xRr-1jk9-vlLSsV7AiPaDh8qmtqLhM4uo1s/edit?usp=sharing).
 3. Review the [Team 3128 2024-25 Safety Training presentation](https://docs.google.com/presentation/d/1q25w3A8jWGKoV8YpriJZneVbZIbcRmN-/edit?usp=sharing&ouid=111489500313563659154&rtpof=true&sd=true).
 4. View the following 7 minute [Safety Video](https://www.youtube.com/watch?v=fivMiePNjCc) on YouTube.

--- a/outreach/sdr-visitors.md
+++ b/outreach/sdr-visitors.md
@@ -5,7 +5,7 @@ subtitle: SDR Visitors
 permalink: /outreach/sdr-visitors/
 ---
 
-# **San Diego Regional: March 20-23, 2024**
+# **San Diego Regional: March 20-23, 2025**
 
 ## FRC Teams in San Diego
 If you have found this website, Hello from FRC 3128 "The Aluminum Narwhals"
@@ -21,7 +21,7 @@ Please contact us at [info@team3128.org](info@team3128.org)
 
 SDR will be held at the Lion Tree Arena on the campus of the University of California at San Diego (UCSD)  -  [9730 Hopkins Dr. La Jolla CA 92093](https://maps.app.goo.gl/bxYfCJs3iHreUewR8)
 
-- [2024 San Diego Regional Website](https://www.firstinspires.org/team-event-search/event?id=68496)
+- [2025 San Diego Regional Website](https://www.firstinspires.org/team-event-search/event?id=72540)
 - [Printable UCSD Map](https://ucsdtritons.com/documents/2019/9/19/CampusMap.pdf)
 - [Interactive UCSD Map and Transportation](https://newtriton.ucsd.edu/get-around/index.html)
 
@@ -48,7 +48,7 @@ The closest Blue Line Trolley station to some hotels listed below is [Nobel Driv
 For more information about MTS services and buying trolley or bus tickets, please visit the [MTS website](http://sdapublic.etaspot.net/)
 
 ## Hotels
-San Diego has many hotesl in many price ranges (in the [SDR Google Map](https://www.google.com/maps/d/u/0/edit?mid=10U3aCFIjo9u0KhcygBLPZHqY0XeNu7v1&ll=32.887237842882584%2C-117.23393556385933&z=15), search for "hotel").
+San Diego has many hotels in many price ranges (in the [SDR Google Map](https://www.google.com/maps/d/u/0/edit?mid=10U3aCFIjo9u0KhcygBLPZHqY0XeNu7v1&ll=32.887237842882584%2C-117.23393556385933&z=15), search for "hotel").
 These are the five closest hotels to the San Diego Regional. The first 3 are walking distance to the San Diego Regional.
 ### Hotels - Walking distance to San Diego Regional at UCSD Liontree arena
 [Residence Inn by Marriott San Diego La Jolla](https://www.marriott.com/en-us/hotels/lajca-residence-inn-san-diego-la-jolla/overview/)


### PR DESCRIPTION
Updating dates for 2025. May not be comprehensive but at least hit the following places:
- Copyright footer
- Auto link to game materials
- Team handbook dates
- SDR Visitor page updates (including new link for the 2025 regional event)